### PR TITLE
Adding consumer_element_id to Add Statement/Component form.

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -2144,6 +2144,7 @@ def save_smt(request):
         # Create new Prototype Statement object on new statement creation (not statement edit)
         if new_statement:
             try:
+                statement.status = None
                 statement_prototype = statement.create_prototype()
             except Exception as e:
                 statement_status = "error"

--- a/controls/views.py
+++ b/controls/views.py
@@ -2109,6 +2109,7 @@ def save_smt(request):
                 statement_type=new_statement_type_enum.name,
                 status=form_values['status'],
                 remarks=form_values['remarks'],
+                consumer_element_id=form_values['consumer_element_id'],
             )
             new_statement = True
 

--- a/templates/controls/add_producer_form.html
+++ b/templates/controls/add_producer_form.html
@@ -38,6 +38,7 @@
                       <div class="form-group">
                         <input type="hidden" id="sid" name="sid" value="{{ control.id }}">
                         <input type="hidden" id="producer_element_id" name="producer_element_id" value="">
+                        <input type="hidden" id="consumer_element_id" name="consumer_element_id" value="{{system.root_element_id}}">
                         <label for="component">Producer Component</label>
                         <input type="text" class="form-control" id="producer_element_name" name="producer_element_name" placeholder="Name of component"
                           onchange="$('#producer_element-panel_num-title').text($(this).val());">


### PR DESCRIPTION
- Log in as a Blueprint user
- Browse to one of your Projects, or create a Project
- From the Project landing page click *Controls*
- From the Controls page click on any *Control*
- Click *Add statement*
- Enter *New Component* into the _Producer Component_ field
- Enter some text into the _What is the solution and how is it implemented?_ field
- Click *Save*

When the page reloads you should see *New Component* listed with the text that you entered.

- Click *Add statement*
- Enter the name of a Component already associated with your Project, but not listed on the page, for instance, *Splunk* into the _Producer Component_ field
- Enter some text into the _What is the solution and how is it implemented?_ field
- Click *Save*

When the page reloads you should see *Splunk* (or whatever Component that you added) listed with the text that you entered.

https://jiraent.cms.gov/browse/ISPGBSS-551
https://jiraent.cms.gov/browse/ISPGBSS-556